### PR TITLE
fix: fullscreen overflowing taskbar

### DIFF
--- a/packages/wm/src/common/events/handle_window_location_changed.rs
+++ b/packages/wm/src/common/events/handle_window_location_changed.rs
@@ -5,7 +5,7 @@ use crate::{
   common::{platform::NativeWindow, Rect},
   containers::{
     commands::{flatten_split_container, move_container_within_tree},
-    traits::{CommonGetters, PositionGetters},
+    traits::CommonGetters,
     WindowContainer,
   },
   try_warn,
@@ -50,14 +50,9 @@ pub fn handle_window_location_changed(
       )?;
     }
 
-    let monitor_rect = if config.has_outer_gaps() {
-      nearest_monitor.native().working_rect()?.clone()
-    } else {
-      nearest_monitor.to_rect()?
-    };
-
-    let is_fullscreen = window.native().is_fullscreen(&monitor_rect)?;
-
+    let is_fullscreen = window.native().is_fullscreen(
+      nearest_monitor.native().working_rect()?
+    )?;
     match window.state() {
       WindowState::Fullscreen(fullscreen_state) => {
         // A fullscreen window that gets minimized can hit this arm, so
@@ -92,9 +87,8 @@ pub fn handle_window_location_changed(
       }
       _ => {
         // Update the window to be fullscreen if there's been a change in
-        // maximized state or if the window is now fullscreen.
-        if (is_maximized && old_is_maximized != is_maximized)
-          || is_fullscreen
+        // maximized state
+        if is_maximized && old_is_maximized != is_maximized
         {
           info!("Window fullscreened");
 

--- a/packages/wm/src/windows/non_tiling_window.rs
+++ b/packages/wm/src/windows/non_tiling_window.rs
@@ -131,7 +131,7 @@ impl PositionGetters for NonTilingWindow {
   fn to_rect(&self) -> anyhow::Result<Rect> {
     match self.state() {
       WindowState::Fullscreen(_) => {
-        self.monitor().context("No monitor.")?.to_rect()
+        Ok(self.monitor().context("No monitor.")?.native().working_rect()?.clone())
       }
       _ => Ok(self.floating_placement()),
     }


### PR DESCRIPTION
This PR fixes fullscreen taskbar alignment regressions.
# Before:

https://github.com/user-attachments/assets/5d4bc8bb-b4ea-4249-bc00-c5302911f818


# After:


https://github.com/user-attachments/assets/32453a86-0c59-4524-a128-2946e3b72fce


